### PR TITLE
issue fixed

### DIFF
--- a/src/routes/reviewRating.routes.ts
+++ b/src/routes/reviewRating.routes.ts
@@ -28,6 +28,6 @@ router.get(
   reviewRatingDashboard
 );
 router.put("/:id", updateReview);
-router.delete("/:id", protect, isAdmin, deleteReview);
+router.delete("/:id", protect, isOrganization, deleteReview);
 
 export default router;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Changes
  - Updated access control for deleting review ratings: action now requires organization-level permissions rather than admin-only access.
  - This change affects who can perform delete operations on review ratings across the API/UI.
  - No other review rating routes or behaviors were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->